### PR TITLE
fix: update lite backend base image and add missing dependency

### DIFF
--- a/backend/Dockerfile.base.lite
+++ b/backend/Dockerfile.base.lite
@@ -3,7 +3,7 @@
 #   docker build -f backend/Dockerfile.base.lite -t dhk-opencv-base:latest .
 #
 # Use this instead of Dockerfile.base when you do NOT need Nvidia Optical Flow.
-FROM nvcr.io/nvidia/pytorch:23.10-py3
+FROM pytorch/pytorch:2.5.0-cuda12.4-cudnn9-runtime
 
 RUN pip uninstall -y \
     opencv-python opencv-python-headless \
@@ -12,4 +12,4 @@ RUN pip uninstall -y \
 # Pin numpy <2.0 to avoid ABI break with compiled extensions
 RUN pip install --no-cache-dir "numpy>=1.24.0,<2.0"
 
-RUN pip install --no-cache-dir "opencv-python-headless==4.8.0.74"
+RUN pip install --no-cache-dir "opencv-python-headless==4.8.0.76"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ numpy>=1.24.0,<2.0
 # opencv-python>=4.8.0
 aiohttp>=3.9.0
 omegaconf>=2.3.0
+matplotlib


### PR DESCRIPTION
- Switch lite base image from nvcr.io/nvidia/pytorch:23.10-py3 to pytorch/pytorch:2.5.0-cuda12.4-cudnn9-runtime
- Bump opencv-python-headless from 4.8.0.74 to 4.8.0.76
- Add matplotlib to requirements.txt